### PR TITLE
Use yaml.safe_load() instead of load().

### DIFF
--- a/pyramid_sawing/main.py
+++ b/pyramid_sawing/main.py
@@ -54,7 +54,7 @@ def includeme(config):
                        .format(PREFIX, PROJECT))
 
     with open(file, 'r') as f:
-        logging_config = yaml.load(f)
+        logging_config = yaml.safe_load(f)
 
     dictConfig(logging_config)
 


### PR DESCRIPTION
yaml.load() is unsafe[0], and calling load() wtihout a Loader
parameter is deprecated. This leads to the following warning:

pyramid_sawing/main.py:57: YAMLLoadWarning: calling yaml.load()
    without Loader=... is deprecated, as the default Loader is
    unsafe. Please read https://msg.pyyaml.org/load for full
    details.
  logging_config = yaml.load(f)

This commit adjusts the package to use yaml.safe_load() instead.

[0] https://pyyaml.org/wiki/PyYAMLDocumentation#loading-yaml

Signed-off-by: Randy Barlow <randy@electronsweatshop.com>